### PR TITLE
redeclare '0' lifetime session

### DIFF
--- a/e107_admin/auth.php
+++ b/e107_admin/auth.php
@@ -183,6 +183,8 @@ else
 			if($sessionLife > 0)
 			{
 				$sessionLife = time() + $sessionLife;
+			}else{
+			     $sessionLife = $sessionLife;
 			}
 
 			session_set(e_COOKIE, $cookieval, $sessionLife);


### PR DESCRIPTION
i'm sorry maybe i was not long enough to test it, but this session problem still bugging me.
with this script addition, session is working fine .. this is to make sure 0 lifetime no need time() to be added.